### PR TITLE
fix(pages.yml): enables Pages for the repository if it is not enabled

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,8 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:


### PR DESCRIPTION
Fixes the issue with GitHub Pages deployment.

Sets the `enablement` input field to true in [actions/configure-pages](https://github.com/actions/configure-pages) to enable Pages for the repository if it is not enabled already.

Reference: https://github.com/actions/configure-pages/blob/d5606572c479bee637007364c6b4800ac4fc8573/action.yml#L19